### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     default: false
     type: boolean
+  mirrorNodePort : 
+    description : 'Port for Mirror Node' 
+    required: false  
+    default : '8080'
 outputs:
   accountId:
     description: "Hedera account id for a new account"
@@ -73,7 +77,7 @@ runs:
       shell: bash
       run: |
         solo mirror-node deploy
-        kubectl port-forward svc/fullstack-deployment-hedera-explorer -n solo-test 8080:80 &
+        kubectl port-forward svc/fullstack-deployment-hedera-explorer -n solo-test ${{ inputs.mirrorNodePort }}:80 &
 
     - name: Create account
       id: create-account


### PR DESCRIPTION
'mirrorNodePort' input parameter is added , allowing user to specify the desired port , default is set to '8080'

'kubectl port-forward ' command is modified to use "${{ inputs.mirrorNodePort }}" ,which pulls the value of mirrorNodePort parameter.